### PR TITLE
Fix ai app preview rendering issue

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -165,6 +165,34 @@ body,
   body {
     @apply bg-background text-foreground;
   }
+  
+  /* Ensure proper layout constraints for resizable panels */
+  .resizable-panel-group {
+    display: flex;
+    height: 100%;
+    width: 100%;
+  }
+  
+  .resizable-panel {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    overflow: hidden;
+  }
+  
+  /* Ensure Sandpack preview doesn't overflow */
+  .sandpack-preview {
+    height: 100% !important;
+    width: 100% !important;
+    overflow: hidden !important;
+  }
+  
+  /* Ensure tabs content doesn't overflow */
+  .tabs-content {
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+  }
 }
 
 @layer base {

--- a/src/modules/projects/ui/components/fragment-sandpack.tsx
+++ b/src/modules/projects/ui/components/fragment-sandpack.tsx
@@ -291,40 +291,46 @@ export default App;`;
     <div className="flex flex-col h-full w-full overflow-hidden">
       <SandpackToolbar />
       
-      <div className="flex-1 min-h-0 overflow-hidden">
-                  <SandpackProvider
-            key={sandpackKey}
-            template="react"
-            files={sandpackFiles}
-            theme="light"
-            customSetup={{
-              dependencies: {
-                "react": "^18.2.0",
-                "react-dom": "^18.2.0",
-                "lucide-react": "^0.469.0",
-                "date-fns": "^4.1.0",
-                "react-chartjs-2": "^5.3.0",
-                "chart.js": "^4.4.7"
-              }
+      <div className="flex-1 min-h-0 overflow-hidden relative">
+        <SandpackProvider
+          key={sandpackKey}
+          template="react"
+          files={sandpackFiles}
+          theme="light"
+          customSetup={{
+            dependencies: {
+              "react": "^18.2.0",
+              "react-dom": "^18.2.0",
+              "lucide-react": "^0.469.0",
+              "date-fns": "^4.1.0",
+              "react-chartjs-2": "^5.3.0",
+              "chart.js": "^4.4.7"
+            }
+          }}
+          options={{
+            visibleFiles: ["/src/App.js"],
+            activeFile: "/src/App.js"
+          }}
+          style={{ height: "100%", width: "100%" }}
+        >
+          <SandpackPreview 
+            showOpenInCodeSandbox={false}
+            showRefreshButton={true}
+            showNavigator={true}
+            className="sandpack-preview"
+            style={{ 
+              height: "100%", 
+              width: "100%",
+              display: "flex",
+              flexDirection: "column",
+              position: "absolute",
+              top: 0,
+              left: 0,
+              right: 0,
+              bottom: 0
             }}
-                         options={{
-               visibleFiles: ["/src/App.js"],
-               activeFile: "/src/App.js"
-             }}
-            style={{ height: "100%", width: "100%" }}
-          >
-            <SandpackPreview 
-              showOpenInCodeSandbox={false}
-              showRefreshButton={true}
-              showNavigator={true}
-              style={{ 
-                height: "100%", 
-                width: "100%",
-                display: "flex",
-                flexDirection: "column"
-              }}
-            />
-          </SandpackProvider>
+          />
+        </SandpackProvider>
       </div>
     </div>
   );

--- a/src/modules/projects/ui/views/project-view.tsx
+++ b/src/modules/projects/ui/views/project-view.tsx
@@ -41,12 +41,13 @@ export const ProjectView = ({
   const [tabState, setTabState] = useState<"preview"|"code">("preview");
 
   return (
-    <div className="h-full">
-      <ResizablePanelGroup direction="horizontal" className="h-full">
+    <div className="h-full w-full overflow-hidden">
+      <ResizablePanelGroup direction="horizontal" className="h-full w-full resizable-panel-group">
         <ResizablePanel
           defaultSize={35}
           minSize={20}
-          className="flex flex-col min-h-0"
+          maxSize={50}
+          className="flex flex-col min-h-0 overflow-hidden resizable-panel"
         >
           <Suspense fallback={<Loader/>}>
             <Header projectId={projectId}/>
@@ -63,14 +64,16 @@ export const ProjectView = ({
         <ResizablePanel
           defaultSize={65}
           minSize={50}
+          maxSize={80}
+          className="flex flex-col min-h-0 overflow-hidden resizable-panel"
         >
           <Tabs
-            className="h-full gap-0"
+            className="h-full w-full flex flex-col"
             defaultValue="preview"
             value={tabState}
             onValueChange={(value)=>setTabState(value as "preview"|"code")}
           >
-            <div className="w-full flex items-center p-2 border-b gap-x-2">
+            <div className="w-full flex items-center p-2 border-b gap-x-2 flex-shrink-0">
               <TabsList className="h-8 p-0 border rounded-md">
                 <TabsTrigger value="preview" className="rounded-md">
                   <EyeIcon/>
@@ -98,7 +101,7 @@ export const ProjectView = ({
                 <UserControl/>
               </div>
             </div>
-            <TabsContent value="preview" className="h-full flex-1">
+            <TabsContent value="preview" className="flex-1 min-h-0 overflow-hidden tabs-content">
               {
                 !!activeFragment ? (
                   <FragmentSandpack
@@ -111,7 +114,7 @@ export const ProjectView = ({
                 )
               }
             </TabsContent>
-            <TabsContent value="code" className="min-h-0">
+            <TabsContent value="code" className="flex-1 min-h-0 overflow-hidden tabs-content">
               {
                 !!activeFragment && (
                   <FragmentCode


### PR DESCRIPTION
Fixes AI-generated app preview rendering by resolving sidebar overlap.

The previous layout caused the left sidebar to overlap the app preview. This PR introduces CSS rules for `ResizablePanelGroup` and `SandpackPreview` to ensure proper overflow handling, panel sizing, and flex distribution, preventing content from spilling and maintaining correct proportions.

---

[Open in Web](https://cursor.com/agents?id=bc-668bc5ff-607a-45e0-bbc0-d09f5b9a4603) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-668bc5ff-607a-45e0-bbc0-d09f5b9a4603) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)